### PR TITLE
Add phone number validation and unit tests to PatientService

### DIFF
--- a/app/src/us/mn/state/health/lims/common/services/PatientService.java
+++ b/app/src/us/mn/state/health/lims/common/services/PatientService.java
@@ -188,6 +188,18 @@ public class PatientService implements IPatientService {
 		personService = new PersonService(patient.getPerson());
 
 	}
+
+	/**
+	 * NEW: Constructor for Dependency Injection.
+	 * Allows injecting a custom PersonService instance (used for testing).
+	 *
+	 * @param patient        Patient entity
+	 * @param personService  PersonService instance to inject
+	 */
+	public PatientService(Patient patient, PersonService personService) {
+		this.patient = patient;
+		this.personService = personService;
+	}
 	
 	/**
 	 * Gets the patient for the sample and then calls the constructor with patient argument
@@ -446,6 +458,7 @@ public class PatientService implements IPatientService {
     public String getPCNumber(){
         return getIdentityInfo(PATIENT_PC_NUMBER_IDENTITY);
     }
+
 
 	public void validatePhoneNumber() {
 		String phone = getPhone();

--- a/app/src/us/mn/state/health/lims/common/services/PatientService.java
+++ b/app/src/us/mn/state/health/lims/common/services/PatientService.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.validation.ValidationException;
 
 import org.apache.commons.validator.GenericValidator;
 
@@ -445,4 +446,11 @@ public class PatientService implements IPatientService {
     public String getPCNumber(){
         return getIdentityInfo(PATIENT_PC_NUMBER_IDENTITY);
     }
+
+	public void validatePhoneNumber() {
+		String phone = getPhone();
+		if (phone != null && !phone.matches("\\d{10}")) {
+			throw new ValidationException("Phone number must be exactly 10 digits.");
+		}
+	}
 }

--- a/app/test/us/mn/state/health/lims/common/PatientServiceTest.java
+++ b/app/test/us/mn/state/health/lims/common/PatientServiceTest.java
@@ -1,0 +1,48 @@
+package us.mn.state.health.lims.common;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import javax.validation.ValidationException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import us.mn.state.health.lims.common.services.PatientService;
+import us.mn.state.health.lims.common.services.PersonService;
+import us.mn.state.health.lims.patient.valueholder.Patient;
+
+class PatientServiceTest {
+
+    private PersonService mockPersonService;
+
+    @BeforeEach
+    void setUp() {
+        mockPersonService = mock(PersonService.class);
+    }
+
+    @Test
+    void savePatient_withValidPhone_shouldPass() {
+        // Mock returns valid phone
+        when(mockPersonService.getPhone()).thenReturn("1234567890");
+
+        PatientService patientService = new PatientService(new Patient(), mockPersonService);
+
+        assertDoesNotThrow(() -> {
+            patientService.validatePhoneNumber();
+        });
+    }
+
+    @Test
+    void savePatient_withInvalidPhone_shouldThrowValidationException() {
+        // Mock returns invalid phone
+        when(mockPersonService.getPhone()).thenReturn("12345");
+
+        PatientService patientService = new PatientService(new Patient(), mockPersonService);
+
+        assertThrows(ValidationException.class, () -> {
+            patientService.validatePhoneNumber();
+        });
+    }
+}


### PR DESCRIPTION
# What does this PR do?
This PR adds server-side phone number validation to the `PatientService` class in the OpenELIS system.  
It ensures that patient phone numbers are exactly 10 digits long.

Additionally:
- A new constructor is introduced to `PatientService` to support Dependency Injection (DI) for easier unit testing.
- Unit tests using Mockito are added to verify the validation logic.

# Changes

## 1. Add phone number validation method in PatientService

- Modified file:  
  `openelisglobal-core/app/src/main/java/us/mn/state/health/lims/common/services/PatientService.java`
- Added `validatePhoneNumber()` method.
- Throws a `ValidationException` if the phone number is not exactly 10 digits.

### Code snippet

```java
public void validatePhoneNumber() {
    String phone = getPhone();
    if (phone != null && !phone.matches("\\d{10}")) {
        throw new ValidationException("Phone number must be exactly 10 digits.");
    }
}
```

---

## 2. Add Dependency Injection (DI) constructor to PatientService

- Modified file:  
  `openelisglobal-core/app/src/main/java/us/mn/state/health/lims/common/services/PatientService.java`
- Added a new constructor to inject a `PersonService` instance manually.
- Improves testability and allows easy mocking of `PersonService` in unit tests.

### Code snippet

```java
public PatientService(Patient patient, PersonService personService) {
    this.patient = patient;
    this.personService = personService;
}
```

---

## 3. Add unit tests for phone number validation

- Added new file:  
  `openelisglobal-core/app/test/us/mn/state/health/lims/common/PatientServiceTest.java`
- Created `PatientServiceTest` class.
- Used **Mockito** to mock `PersonService`.
- Added two unit tests:
  - Valid phone number (10 digits) ➔ no exception thrown.
  - Invalid phone number (less than 10 digits) ➔ `ValidationException` thrown.

### Code snippet

```java
@Test
void savePatient_withValidPhone_shouldPass() {
    when(mockPersonService.getPhone()).thenReturn("1234567890");
    PatientService patientService = new PatientService(new Patient(), mockPersonService);

    assertDoesNotThrow(() -> {
        patientService.validatePhoneNumber();
    });
}

@Test
void savePatient_withInvalidPhone_shouldThrowValidationException() {
    when(mockPersonService.getPhone()).thenReturn("12345");
    PatientService patientService = new PatientService(new Patient(), mockPersonService);

    assertThrows(ValidationException.class, () -> {
        patientService.validatePhoneNumber();
    });
}
```


---

# Additional Notes
- No existing functionality was changed or broken; the new method is isolated and backward-compatible.
- The code was tested locally with `mvn clean test` and passed successfully.
- I would greatly appreciate your review and feedback. 🙏
